### PR TITLE
DROOP-43: Add class to header selector

### DIFF
--- a/themes/custom/droopler_theme/scss/layout/_header.scss
+++ b/themes/custom/droopler_theme/scss/layout/_header.scss
@@ -10,7 +10,7 @@ $logo-mobile-padding-left: 1rem !default;
 $logo-md-width: 13.5rem !default;
 
 
-header {
+header.header {
   .site-logo img {
     max-width: 100%;
     max-height: $header-height - (2 * $navbar-padding-y);


### PR DESCRIPTION
Z tego co widziałem w całym projekcie nie zdarza się żaden inny element header z klasą “header” poza tym górnym, więc w sumie dodałem tylko to.