### PR TITLE
Droop 67: Fix Facebook video embed

### DIFF
--- a/modules/custom/d_p_side_embed/d_p_side_embed.libraries.yml
+++ b/modules/custom/d_p_side_embed/d_p_side_embed.libraries.yml
@@ -1,0 +1,7 @@
+d_p_side_embed:
+  version: VERSION
+  js:
+    js/d_p_side_embed.js: {}
+  dependencies:
+  - core/jquery
+  - core/drupal

--- a/modules/custom/d_p_side_embed/js/d_p_side_embed.js
+++ b/modules/custom/d_p_side_embed/js/d_p_side_embed.js
@@ -14,7 +14,6 @@
           width: $wrapper.width(),
           height: $wrapper.height()
         };
-        console.log(wrapperDimensions);
         var videoDimensions = {
           width: $wrapper.height() * aspectRatio.horizontal,
           height: $wrapper.height()

--- a/modules/custom/d_p_side_embed/js/d_p_side_embed.js
+++ b/modules/custom/d_p_side_embed/js/d_p_side_embed.js
@@ -1,0 +1,48 @@
+/**
+ * @file
+ * The script that scales facebook video iframes.
+ */
+
+(function ($) {
+  'use strict';
+
+  Drupal.behaviors.d_p_side_embed = {
+    attach: function (context, settings) {
+
+      function resizeVideo($video, $wrapper, aspectRatio) {
+        var wrapperDimensions = {
+          width: $wrapper.width(),
+          height: $wrapper.height()
+        };
+        console.log(wrapperDimensions);
+        var videoDimensions = {
+          width: $wrapper.height() * aspectRatio.horizontal,
+          height: $wrapper.height()
+        };
+        if (videoDimensions.width > wrapperDimensions.width) {
+          videoDimensions.width = wrapperDimensions.width;
+          videoDimensions.height = $wrapper.width() * aspectRatio.vertical;
+        }
+        $video.css(videoDimensions);
+      }
+
+      $('.paragraph--type--d-p-side-embed', context).once('d_p_side_embed').each(function () {
+        var $videoWrapper = $(this).find('.d-p-side-embed-embed');
+        var $video = $videoWrapper.find('iframe');
+        if ($video.length === 0 || $video.attr('src').indexOf('https://www.facebook.com') !== 0) {
+          return;
+        }
+
+        var aspectRatio = {
+          horizontal: $video.attr('width') / $video.attr('height'),
+          vertical: $video.attr('height') / $video.attr('width')
+        };
+        $video.addClass('facebook-video');
+        resizeVideo($video, $videoWrapper, aspectRatio);
+        $(window).resize(function () {
+          resizeVideo($video, $videoWrapper, aspectRatio);
+        });
+      });
+    }
+  };
+})(jQuery);

--- a/themes/custom/droopler_theme/scss/components/_d_p_side_embed.scss
+++ b/themes/custom/droopler_theme/scss/components/_d_p_side_embed.scss
@@ -58,6 +58,9 @@ $d-p-side-embed-desktop-height: auto !default; // You can set fixed height of em
   }
 
   .d-p-side-embed-embed {
+    display: flex;
+    justify-content: center;
+    align-items: center;
     padding-left: 0;
     padding-right: 0;
     position: relative;
@@ -75,6 +78,10 @@ $d-p-side-embed-desktop-height: auto !default; // You can set fixed height of em
       flex-direction: column;
       justify-content: center;
       align-items: center;
+      &.facebook-video {
+        position: static;
+        max-width: 100%;
+      }
     }
   }
 


### PR DESCRIPTION
Sprawdzane dla różnych rozmiarów video z facebooka (horizontal i vertical).
Nie wiedziałem tylko czy dać na wrapper z video czarny background, żeby symulować to co robi youtube player z automatu (środkuje video zgodnie z proporcjami a na reszte contentu daje czarne pasy).