### PR TITLE
DROOP-232-check-dependencies-d-content: removed svg_image

### DIFF
--- a/modules/custom/d_content/d_content.info.yml
+++ b/modules/custom/d_content/d_content.info.yml
@@ -32,7 +32,6 @@ dependencies:
   - node
   - paragraphs
   - path
-  - svg_image
   - system
   - text
   - user

--- a/modules/custom/d_content/d_content.info.yml
+++ b/modules/custom/d_content/d_content.info.yml
@@ -29,6 +29,7 @@ dependencies:
   - menu_ui
   - metatag
   - metatag_open_graph
+  - svg_image
   - node
   - paragraphs
   - path

--- a/modules/custom/d_p_side_image/d_p_side_image.info.yml
+++ b/modules/custom/d_p_side_image/d_p_side_image.info.yml
@@ -12,7 +12,6 @@ dependencies:
   - link_attributes
   - options
   - paragraphs
-  - svg_image
   - text
 package: Paragraphs
 version: 8.x-1.4


### PR DESCRIPTION
svg_image is called by d_p_side_image, no need to call it directly