### PR TITLE
DD-81 Content init - search for referenced entity by properties inste…

### DIFF
--- a/modules/custom/d_content/modules/d_content_init/d_content_init.module
+++ b/modules/custom/d_content/modules/d_content_init/d_content_init.module
@@ -150,6 +150,16 @@ function d_content_init_fill_field($entity, $name, $value) {
       }
       break;
     case 'entity_reference':
+      if (isset($value['data']['target_search'])) {
+        $target_entity_type = $value['data']['target_type'] ?? 'node';
+        if ($target_entity = d_content_init_find_entity_by_properties($value['data']['target_search'], $target_entity_type)) {
+          $entity->set($name, [['target_id' => $target_entity->id()]]);
+        }
+      }
+      else {
+        $entity->set($name, $value['data']);
+      }
+      break;
     case 'boolean':
     case 'number':
       $entity->set($name, $value['data']);
@@ -326,6 +336,27 @@ function d_content_init_get_file($path, $dst_dir = NULL) {
   $data = file_get_contents("$dir/assets/$filename");
   $image = file_save_data($data, $directory . $filename, FILE_EXISTS_REPLACE);
   return $image;
+}
+
+/**
+ * Search for entity by its properties
+ *
+ * @param array $properties
+ *   Array of the properties.
+ * @param string $entity_type
+ *   Type of the entity to find.
+ *
+ * @return bool|\Drupal\Core\Entity\EntityInterface|FALSE
+ *   First found entity or FALSE.
+ *
+ * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+ * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+ */
+function d_content_init_find_entity_by_properties(array $properties, $entity_type = 'node') {
+  $entities = \Drupal::entityTypeManager()
+    ->getStorage($entity_type)
+    ->loadByProperties($properties);
+  return $entities ? reset($entities) : FALSE;
 }
 
 /**

--- a/modules/custom/d_demo/pages/homepage.yml
+++ b/modules/custom/d_demo/pages/homepage.yml
@@ -168,7 +168,9 @@ field_page_section:
               field_d_node_reference:
                 type: entity_reference
                 data:
-                  target_id: 25
+                  target_search:
+                    title: "Classic Black Piano"
+                    type: d_product
           - type: d_p_node
             data:
               field_d_display_mode:
@@ -177,7 +179,9 @@ field_page_section:
               field_d_node_reference:
                 type: entity_reference
                 data:
-                  target_id: 24
+                  target_search:
+                    title: "Front Brown Natual Leather Seats for BMW Series 5 M 2012-2013 Before FL"
+                    type: d_product
           - type: d_p_node
             data:
               field_d_display_mode:
@@ -186,7 +190,9 @@ field_page_section:
               field_d_node_reference:
                 type: entity_reference
                 data:
-                  target_id: 23
+                  target_search:
+                    title: "High Class Classic Wooden Piano"
+                    type: d_product
 
   - paragraph_type: d_p_group_of_text_blocks
     data:
@@ -339,8 +345,8 @@ field_page_section:
       field_d_main_title:
         type: text
         data: Blog
-      field_d_p_reference_content:
-        type: entity_reference
+      # field_d_p_reference_content:
+      #   type: entity_reference
       field_d_cta_link:
         type: cta
         data:

--- a/modules/custom/d_demo/pages/homepage.yml
+++ b/modules/custom/d_demo/pages/homepage.yml
@@ -345,8 +345,6 @@ field_page_section:
       field_d_main_title:
         type: text
         data: Blog
-      # field_d_p_reference_content:
-      #   type: entity_reference
       field_d_cta_link:
         type: cta
         data:

--- a/modules/custom/d_product/d_product_init/d_product_init.module
+++ b/modules/custom/d_product/d_product_init/d_product_init.module
@@ -21,9 +21,11 @@ function d_product_init_content_structure_alter(&$structure, $context) {
   $path = drupal_get_path('module', 'd_product_init') . '/pages';
 
   if ($context == 'all') {
+    $products = [];
     for ($i = 1; $i <= 3; $i++) {
-      $structure['product_' . $i] = ['file' => "$path/product_{$i}.yml"];
+      $products['product_' . $i] = ['file' => "$path/product_{$i}.yml", 'weight' => 0];
     }
+    $structure = $products + $structure;
   }
 }
 


### PR DESCRIPTION
Dodałem wyszukiwanie encji do której ma być referencja:

```
field_d_node_reference:
  type: entity_reference
  data:
    target_type: node
    target_search:
      title: "High Class Classic Wooden Piano"
      type: d_product
```

target_type - opcjonalny type encji do wyszukania, jak nie jest zdefiniowane to == node
target_search - cokolwiek co możemy przekazać do metody loadByProperties w storage

---

Na tą chwilę jest kilka problemów, z którymi nie łatwo będzie się uporać bez przebudowy działania tego modułu:

Szukana encja musi być wcześniej dodana np.: w homepage.yml z d_demo mamy referencje do produktów, które są dopisywane przez alter w module d_product, wywoływanym później. Aby się  z tym uporać w d_products na tą chwilę dopisuje YMLe na początek tablicy ale to śliskie rozwiązanie.

Nie wiem czy jest sens dodawać szukanie encji po danych z innego YMLa, nie wiem czy jest on dopisany do dodanie w alterze i jak wyżej musiałby być zrealizowany wcześniej niż YML z tą referencją.  

Myślałem o ustawianiu jakiejś wagi dla pliku i potem sobie wg tej wagi realizować YMLe ale na ta chwilę jest już waga, która używana jest dla linku w menu także trzeba by zmienić strukturę tablicy z YMLami do dodania.

Najlepiej jednak byłoby bo to przepisać do serwisu i realizować te relacje przez choćby jakieś placeholdery itp

---

Generalnie działa, jednak trzeba pamiętać o kolejności plików.