### PR TITLE
DD-277 Remove warnings and notices during Droopler install

### DIFF
--- a/modules/custom/d_content/modules/d_content_init/d_content_init.module
+++ b/modules/custom/d_content/modules/d_content_init/d_content_init.module
@@ -300,6 +300,7 @@ function d_content_init_add_node($params) {
     if ($homepage) {
       $config = \Drupal::configFactory()->getEditable('system.site');
       $config->set('page.front', '/node/' . $nid)->save();
+      $params['parent'] = 'standard.front_page';
     }
   }
 
@@ -316,6 +317,17 @@ function d_content_init_add_node($params) {
     // Handle submenus.
     if (!empty($params['parent'])) {
       $config['parent'] = $params['parent'];
+    }
+    else {
+      $config['parent'] = 'menu_link_content:';
+    }
+
+    // Make sure that there is anything in we_megamenu's table config field.
+    if (\Drupal::service('module_handler')->moduleExists('we_megamenu')) {
+      $menu_config = WeMegaMenuBuilder::loadConfig('main', 'droopler_theme');
+      if (empty($menu_config)) {
+        WeMegaMenuBuilder::saveConfig('main', 'droopler_theme', '{"menu_config":{}}');
+      }
     }
 
     // Save link.

--- a/modules/custom/d_product/config/install/views.view.products_list.yml
+++ b/modules/custom/d_product/config/install/views.view.products_list.yml
@@ -65,7 +65,7 @@ display:
               slider_options:
                 bef_slider_min: null
                 bef_slider_max: null
-                bef_slider_step: !!float 1
+                bef_slider_step: null
                 bef_slider_animate: ''
                 bef_slider_orientation: horizontal
               more_options:


### PR DESCRIPTION
Made sure that we_megamenu table is not empty before trying to insert nodes. Changed bef_slider to null to avoid issue with field being untranslatable.