### PR TITLE
#0 fixing incorrect tags closing order

### DIFF
--- a/modules/custom/d_p_text_blocks/templates/field--field-d-p-tb-block-reference.html.twig
+++ b/modules/custom/d_p_text_blocks/templates/field--field-d-p-tb-block-reference.html.twig
@@ -74,5 +74,5 @@
     </div>
     {% endif %}
   </div>
+  {% endif %}
 </section>
-{% endif %}


### PR DESCRIPTION
Dear Grzegorz ;) 
Running page Html validator I was getting many errors with incorrect tag closing. They were all caused by this incorrect endif placement. Please  Approve it asap :crossed_fingers: 