### PR TITLE
DROOP-555 fix menu layout when no secondary present

### DIFF
--- a/themes/custom/droopler_theme/scss/layout/_header.scss
+++ b/themes/custom/droopler_theme/scss/layout/_header.scss
@@ -112,11 +112,25 @@ header.header {
     }
   }
   > nav.navbar-wrapper {
+    padding-bottom: 0;
 
     @include media-breakpoint-up($navbar-mobile-breakpoint-up) {
-      padding-top: $navbar-padding-y;
+      .menu-region {
+        padding-top: 1rem;
+
+        nav.main > .we-mega-menu-ul > .we-mega-menu-li {
+          padding-bottom: calc(1rem + 10px);
+        }
+      }
+
+      .secondary-menu-region + .menu-region {
+        padding-top: 0;
+
+        nav.main > .we-mega-menu-ul > .we-mega-menu-li {
+          padding-bottom: 0;
+        }
+      }
     }
-    padding-bottom: 0;
   }
 
   .navbar {


### PR DESCRIPTION
Remove unnecessary top padding, add rules for main navbar when secondary menu is not present.