### PR TITLE
DROOP-550 improvements in theme-styling

### DIFF
--- a/themes/custom/droopler_theme/scss/layout/_modifiers.scss
+++ b/themes/custom/droopler_theme/scss/layout/_modifiers.scss
@@ -490,6 +490,11 @@ $d-p-themes: map-merge(
         .field {
           color: map-get($themeSettings, "text");
         }
+        @for $i from 1 through 6 {
+          h#{$i} {
+            color: map-get($themeSettings, "text");
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
zauwazylem, ze jak jest `h2` w `div.field` to h2 ma mocniejsze stylowanie i to z .field nie wystarcza