### PR TITLE
Hotfix: Lazy module version hardcoded to 3.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "drupal/geysir": "^1.2",
         "drupal/google_analytics": "^2.2",
         "drupal/google_tag": "1.x-dev",
-        "drupal/lazy": "^3.4",
+        "drupal/lazy": "3.4",
         "drupal/link_attributes": "^1.1",
         "drupal/linkit": "^4.3",
         "drupal/menu_link_attributes": "^1.0",


### PR DESCRIPTION
This will be reverted in Droopler 2.2 release. Currently Droopler 2.1 does not support "lazy" module >= 3.5.