### PR TITLE
SettingsWidget::getConfigOptions() should not return NULL.

### DIFF
--- a/modules/custom/d_p/src/Plugin/Field/FieldWidget/SettingsWidget.php
+++ b/modules/custom/d_p/src/Plugin/Field/FieldWidget/SettingsWidget.php
@@ -434,8 +434,9 @@ class SettingsWidget extends WidgetBase {
         ],
       ],
     ];
-    
-    return \Drupal::moduleHandler()->alter('d_settings', $form);
+
+    \Drupal::moduleHandler()->alter('d_settings', $form);
+    return $form;
   }
 
   /**


### PR DESCRIPTION
Fixes fatal error introduced recently in #663.