### PR TITLE
fix(d_geysir): add missing trailing slash for base url

### DIFF
--- a/modules/custom/d_geysir/d_geysir.module
+++ b/modules/custom/d_geysir/d_geysir.module
@@ -21,7 +21,7 @@ function d_geysir_form_alter(&$form, FormStateInterface $form_state, $form_id) {
       foreach ($form['description'] as $paragraph_name => $attributes) {
         $file_server_path = $root_path . '/' . $module_path . '/images/' . $paragraph_name . '.png';
         if (file_exists($file_server_path)) {
-          $file_url = $base_url . $module_path . '/images/' . $paragraph_name . '.png';
+          $file_url = $base_url . '/' . $module_path . '/images/' . $paragraph_name . '.png';
           $form['description'][$paragraph_name]['#src'] = $file_url;
         }
       }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1732227/99276246-c09b3000-282c-11eb-942b-061d4b7cd16b.png)

```
<div class="geysir-add-type">

<!-- THEME DEBUG -->
<!-- THEME HOOK: 'input__image_button' -->
<!-- FILE NAME SUGGESTIONS:
   * input--image-button.html.twig
   x input.html.twig
-->
<!-- BEGIN OUTPUT from 'profiles/contrib/droopler/themes/custom/droopler_theme/templates/form/input.html.twig' -->
<input data-drupal-selector="edit-d-p-banner" type="image" id="edit-d-p-banner--0gJIobaxfwY" name="op" value="Banner" src="/droopler.com/webprofiles/contrib/droopler/modules/custom/d_p/images/d_p_banner.png" class="image-button js-form-submit form-submit form-control">

<!-- END OUTPUT from 'profiles/contrib/droopler/themes/custom/droopler_theme/templates/form/input.html.twig' -->

<span>Banner</span></div>
```

The problem occurs when you install droopler under nested dirs structure.

**BEFORE:**
`src="/droopler.com/webprofiles/contrib/droopler/modules/custom/d_p/images/d_p_banner.png"`
**AFTER**
`src="/droopler.com/web/profiles/contrib/droopler/modules/custom/d_p/images/d_p_banner.png"`
