### PR TITLE
Issue #3272717: Fix wide sidebar image

### DIFF
--- a/modules/custom/d_p_side_image/templates/paragraph--d-p-side-image.html.twig
+++ b/modules/custom/d_p_side_image/templates/paragraph--d-p-side-image.html.twig
@@ -54,7 +54,9 @@
   'clearfix',
   'position-relative',
 ] %}
-{% set content_side_classes = ['content-inside-wrapper',] %}
+{% set content_side_classes = [
+  'content-inside-wrapper',
+] %}
 {% set content_side_classes = content_side_classes|merge([text_class]) %}
 
 {% block paragraph %}

--- a/modules/custom/d_p_side_image/templates/paragraph--d-p-side-image.html.twig
+++ b/modules/custom/d_p_side_image/templates/paragraph--d-p-side-image.html.twig
@@ -54,14 +54,10 @@
   'clearfix',
   'position-relative',
 ] %}
-{% set content_side_classes = [
-  'content-inside-wrapper',
-]
-%}
+{% set content_side_classes = ['content-inside-wrapper',] %}
 {%
   set content_side_classes = content_side_classes|merge([text_class])
 %}
-
 {% block paragraph %}
 <section {{ wrapper_attributes }}>
   <div{{ attributes.addClass(classes) }}>

--- a/modules/custom/d_p_side_image/templates/paragraph--d-p-side-image.html.twig
+++ b/modules/custom/d_p_side_image/templates/paragraph--d-p-side-image.html.twig
@@ -56,7 +56,11 @@
 ] %}
 {% set content_side_classes = [
   'content-inside-wrapper',
-] %}
+]
+%}
+{%
+  set content_side_classes = content_side_classes|merge([text_class])
+%}
 
 {% block paragraph %}
 <section {{ wrapper_attributes }}>
@@ -72,7 +76,7 @@
       <div class="{{ content_side_classes|join(' ') }}">
         <div class="container">
           <div class="row">
-            <div class="{{ text_class }} container-half">
+            <div class="container-half">
               {{ content.group_d_side_image_content }}
               {% if content.group_d_side_image_cta %}
                 <div class="mt-4">

--- a/modules/custom/d_p_side_image/templates/paragraph--d-p-side-image.html.twig
+++ b/modules/custom/d_p_side_image/templates/paragraph--d-p-side-image.html.twig
@@ -55,9 +55,8 @@
   'position-relative',
 ] %}
 {% set content_side_classes = ['content-inside-wrapper',] %}
-{%
-  set content_side_classes = content_side_classes|merge([text_class])
-%}
+{% set content_side_classes = content_side_classes|merge([text_class]) %}
+
 {% block paragraph %}
 <section {{ wrapper_attributes }}>
   <div{{ attributes.addClass(classes) }}>


### PR DESCRIPTION
I moved text_class that was containing proper bootstrap grid settings to the correct element to fix the issue.