### PR TITLE
Allow php composer installer

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -35,6 +35,9 @@ jobs:
           coverage: none
           tools: composer, phpcs
 
+      - name: Allow phpcs composer installer
+        run: composer config --global --no-plugins allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
+
       - name: Download Drupal coding standards
         run: composer global require --no-progress --no-suggest --no-scripts --no-plugins --optimize-autoloader slevomat/coding-standard:^7.0 drupal/coder
 


### PR DESCRIPTION
This pull request is fixing the problem with allow-plugins and code sniffer running.