### PR TITLE
Compatibility with D11.4 and bugfixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "drupal/pathauto": "^1.14",
         "drupal/redirect": "^1.13",
         "drupal/schema_metatag": "^3.0",
-        "drupal/search_api": "^1.40",
+        "drupal/search_api": "^1.41",
         "drupal/simple_sitemap": "^4.2",
         "drupal/smtp": "^1.4",
         "drupal/svg_image": "^3.2",

--- a/composer.json
+++ b/composer.json
@@ -96,6 +96,7 @@
             "drupal/core-project-message": true,
             "php-http/discovery": true,
             "phpstan/extension-installer": true,
+            "symfony/runtime": true,
             "tbachert/spi": true
         }
     },

--- a/droopler.info.yml
+++ b/droopler.info.yml
@@ -96,6 +96,6 @@ themes:
   - droopler_theme
 distribution:
   name: 'Droopler Profile'
-version: 3.6.0
+version: 3.6.1
 project: droopler
 core_incompatible: false

--- a/droopler.install
+++ b/droopler.install
@@ -10,6 +10,7 @@ use Drupal\Core\Extension\MissingDependencyException;
 use Drupal\d_p\ParagraphSettingTypesInterface;
 use Drupal\d_p\Plugin\Field\FieldType\ConfigurationStorage;
 use Drupal\field\Entity\FieldConfig;
+use Drupal\shortcut\Entity\Shortcut;
 use Drupal\user\Entity\Role;
 use Drupal\we_megamenu\WeMegaMenuBuilder;
 
@@ -21,9 +22,31 @@ use Drupal\we_megamenu\WeMegaMenuBuilder;
  * @see system_install()
  */
 function droopler_install() {
-  // First, do everything in standard profile.
-  include_once DRUPAL_ROOT . '/core/profiles/standard/standard.install';
-  standard_install();
+  // Seed the default shortcut set. Drupal 11.4 removed
+  // core/profiles/standard/standard.install (whose standard_install() only did
+  // this); call it when present and replicate it otherwise, so the profile
+  // installs on both Drupal 11.3 and 11.4+.
+  $standard_install = DRUPAL_ROOT . '/core/profiles/standard/standard.install';
+  if (is_file($standard_install)) {
+    include_once $standard_install;
+  }
+  if (function_exists('standard_install')) {
+    standard_install();
+  }
+  else {
+    Shortcut::create([
+      'shortcut_set' => 'default',
+      'title' => (string) t('Add content'),
+      'weight' => -20,
+      'link' => ['uri' => 'internal:/node/add'],
+    ])->save();
+    Shortcut::create([
+      'shortcut_set' => 'default',
+      'title' => (string) t('All content'),
+      'weight' => -19,
+      'link' => ['uri' => 'internal:/admin/content'],
+    ])->save();
+  }
 
   \Drupal::configFactory()
     ->getEditable('node.settings')

--- a/modules/custom/d_block_field/src/Plugin/Field/FieldFormatter/BlockFieldFormatter.php
+++ b/modules/custom/d_block_field/src/Plugin/Field/FieldFormatter/BlockFieldFormatter.php
@@ -37,10 +37,10 @@ class BlockFieldFormatter extends FormatterBase implements ContainerFactoryPlugi
     $label,
     $view_mode,
     array $third_party_settings,
-    protected readonly ContextRepositoryInterface $contextRepository,
-    protected readonly ContextHandlerInterface $contextHandler,
-    protected readonly RendererInterface $renderer,
-    protected readonly AccountInterface $currentUser,
+    protected ContextRepositoryInterface $contextRepository,
+    protected ContextHandlerInterface $contextHandler,
+    protected RendererInterface $renderer,
+    protected AccountInterface $currentUser,
   ) {
     parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $label, $view_mode, $third_party_settings);
   }

--- a/modules/custom/d_block_field/src/Plugin/Field/FieldFormatter/BlockFieldLabelFormatter.php
+++ b/modules/custom/d_block_field/src/Plugin/Field/FieldFormatter/BlockFieldLabelFormatter.php
@@ -33,8 +33,8 @@ class BlockFieldLabelFormatter extends FormatterBase implements ContainerFactory
     $label,
     $view_mode,
     array $third_party_settings,
-    protected readonly RendererInterface $renderer,
-    protected readonly AccountInterface $currentUser,
+    protected RendererInterface $renderer,
+    protected AccountInterface $currentUser,
   ) {
     parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $label, $view_mode, $third_party_settings);
   }

--- a/modules/custom/d_block_field/src/Plugin/Field/FieldWidget/BlockFieldWidget.php
+++ b/modules/custom/d_block_field/src/Plugin/Field/FieldWidget/BlockFieldWidget.php
@@ -41,9 +41,9 @@ class BlockFieldWidget extends WidgetBase implements ContainerFactoryPluginInter
     FieldDefinitionInterface $field_definition,
     array $settings,
     array $third_party_settings,
-    protected readonly BlockManagerInterface $blockManager,
-    protected readonly BlockFieldManagerInterface $fieldManager,
-    protected readonly ContextRepositoryInterface $contextRepository,
+    protected BlockManagerInterface $blockManager,
+    protected BlockFieldManagerInterface $fieldManager,
+    protected ContextRepositoryInterface $contextRepository,
   ) {
     parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $third_party_settings);
   }

--- a/modules/custom/d_commerce/modules/d_commerce_product/d_commerce_product.module
+++ b/modules/custom/d_commerce/modules/d_commerce_product/d_commerce_product.module
@@ -18,7 +18,11 @@ function d_commerce_product_preprocess_field(&$variables) {
     switch ($variables['field_name']) {
       case 'field_product_images':
         $variables['#attached']['library'][] = 'd_commerce_product/d_product_commerce_slider';
-        $slider = views_embed_view('commerce_product_images', 'block_1');
+        $slider = [
+          '#type' => 'view',
+          '#name' => 'commerce_product_images',
+          '#display_id' => 'block_1',
+        ];
         $variables['slider'] = \Drupal::service('renderer')->render($slider);
         break;
 

--- a/modules/custom/d_commerce/modules/d_commerce_products_list/d_commerce_products_list.module
+++ b/modules/custom/d_commerce/modules/d_commerce_products_list/d_commerce_products_list.module
@@ -7,6 +7,7 @@
 
 use Drupal\Component\Plugin\Exception\PluginException;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
 use Drupal\commerce_product\Entity\ProductInterface;
 use Drupal\facets\Entity\Facet;
 use Drupal\search_api\Plugin\views\query\SearchApiQuery;
@@ -76,16 +77,18 @@ function d_commerce_products_list_preprocess_field(&$variables) {
       $view_id = 'view.droopler_commerce_products_list.page_1';
 
       $facet = Facet::load($facet_id);
-      $alias_cleaner = Drupal::service('pathauto.alias_cleaner');
+      if ($facet === NULL) {
+        return;
+      }
 
       foreach ($variables['element']['#items'] as $key => $item) {
-        $taxonomy_name = $alias_cleaner->cleanString($variables['element'][$key]['#title']);
-
-        $view_url = $variables['element'][$key]['#url']->fromRoute($view_id, [
-          'arg_0' => $facet->getUrlAlias(),
-          'arg_1' => $taxonomy_name,
+        // Facets pretty paths uses a single {facets_query} segment holding the
+        // raw facet value; the old arg_0/arg_1 + cleanString path no longer
+        // matches the term name and breaks filtering.
+        $facets_query = $facet->getUrlAlias() . '/' . $variables['element'][$key]['#title'];
+        $variables['items'][$key]['content']['#url'] = Url::fromRoute($view_id, [
+          'facets_query' => $facets_query,
         ]);
-        $variables['items'][$key]['content']['#url'] = $view_url;
       }
     }
   }

--- a/modules/custom/d_media/src/Plugin/Field/FieldFormatter/VideoEmbedFormatter.php
+++ b/modules/custom/d_media/src/Plugin/Field/FieldFormatter/VideoEmbedFormatter.php
@@ -47,8 +47,8 @@ class VideoEmbedFormatter extends FormatterBase implements ContainerFactoryPlugi
     $label,
     $view_mode,
     array $third_party_settings,
-    protected readonly ProviderManagerInterface $providerManager,
-    protected readonly EntityStorageInterface $imageStyleStorage,
+    protected ProviderManagerInterface $providerManager,
+    protected EntityStorageInterface $imageStyleStorage,
   ) {
     parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $label, $view_mode, $third_party_settings);
   }

--- a/modules/custom/d_media/src/Plugin/Provider/ProviderPluginBase.php
+++ b/modules/custom/d_media/src/Plugin/Provider/ProviderPluginBase.php
@@ -65,7 +65,7 @@ abstract class ProviderPluginBase extends PluginBase implements ProviderPluginIn
     array $configuration,
     string $plugin_id,
     array $plugin_definition,
-    protected readonly EntityTypeManagerInterface $entityTypeManager,
+    protected EntityTypeManagerInterface $entityTypeManager,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
 

--- a/modules/custom/d_p/src/Hook/Hooks.php
+++ b/modules/custom/d_p/src/Hook/Hooks.php
@@ -84,8 +84,11 @@ class Hooks {
     }
 
     $setting_field = ParagraphSettingsAccessor::field($paragraph);
-    if ($setting_field !== NULL && !$setting_field->isEmpty()) {
+    if ($setting_field !== NULL) {
       unset($variables['content'][$setting_field->getName()]);
+      // Apply classes even when the field is empty: getClasses() emits the
+      // configured per-modifier defaults (padding/margin/theme), which legacy
+      // paragraphs with no stored settings still need for correct spacing.
       $wrapper_attributes['class'] = array_merge(
         $wrapper_attributes['class'],
         $setting_field->getClasses(),

--- a/modules/custom/d_p/src/ParagraphSettingPluginBase.php
+++ b/modules/custom/d_p/src/ParagraphSettingPluginBase.php
@@ -11,6 +11,12 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides base plugin implementation for paragraph setting plugins.
+ *
+ * $settingManager is intentionally not readonly: PluginBase uses
+ * DependencySerializationTrait, whose __wakeup() reinjects services by
+ * assigning to the property from PluginBase scope. A readonly promoted property
+ * can only be initialized from its declaring class scope, so unserializing a
+ * cached plugin would throw "Cannot initialize readonly property".
  */
 abstract class ParagraphSettingPluginBase extends PluginBase implements ParagraphSettingInterface, ContainerFactoryPluginInterface {
 
@@ -18,7 +24,7 @@ abstract class ParagraphSettingPluginBase extends PluginBase implements Paragrap
     array $configuration,
     string $plugin_id,
     mixed $plugin_definition,
-    protected readonly ParagraphSettingPluginManagerInterface $settingManager,
+    protected ParagraphSettingPluginManagerInterface $settingManager,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
   }

--- a/modules/custom/d_p/src/Plugin/Field/FieldWidget/SettingsWidget.php
+++ b/modules/custom/d_p/src/Plugin/Field/FieldWidget/SettingsWidget.php
@@ -38,7 +38,7 @@ class SettingsWidget extends WidgetBase {
     FieldDefinitionInterface $field_definition,
     array $settings,
     array $third_party_settings,
-    protected readonly ParagraphSettingPluginManagerInterface $paragraphSettingsManager,
+    protected ParagraphSettingPluginManagerInterface $paragraphSettingsManager,
   ) {
     parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $third_party_settings);
   }

--- a/modules/custom/d_p_subscribe_file/src/Forms/SubscribeFileForm.php
+++ b/modules/custom/d_p_subscribe_file/src/Forms/SubscribeFileForm.php
@@ -15,6 +15,12 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * File subscribe form.
+ *
+ * Injected services are intentionally not readonly: FormBase uses
+ * DependencySerializationTrait, whose __wakeup() reinjects them by property
+ * assignment from trait scope when a cached form is unserialized. A readonly
+ * promoted property can only be initialized from its declaring class scope, so
+ * unserializing would throw "Cannot initialize readonly property".
  */
 class SubscribeFileForm extends FormBase {
 
@@ -29,8 +35,8 @@ class SubscribeFileForm extends FormBase {
   protected ?ParagraphInterface $paragraph = NULL;
 
   public function __construct(
-    protected readonly AccountInterface $currentUser,
-    protected readonly MailManagerInterface $mailManager,
+    protected AccountInterface $currentUser,
+    protected MailManagerInterface $mailManager,
   ) {}
 
   /**

--- a/modules/custom/d_p_subscribe_file/src/Hook/Hooks.php
+++ b/modules/custom/d_p_subscribe_file/src/Hook/Hooks.php
@@ -6,7 +6,6 @@ namespace Drupal\d_p_subscribe_file\Hook;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\DependencyInjection\ClassResolverInterface;
-use Drupal\Core\Form\FormBuilderInterface;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\Core\Render\Markup;
 use Drupal\Core\Render\RendererInterface;
@@ -22,7 +21,6 @@ class Hooks {
 
   public function __construct(
     protected readonly ClassResolverInterface $classResolver,
-    protected readonly FormBuilderInterface $formBuilder,
     protected readonly ConfigFactoryInterface $configFactory,
     protected readonly RendererInterface $renderer,
   ) {}
@@ -39,7 +37,10 @@ class Hooks {
     $form_object = $this->classResolver->getInstanceFromDefinition(SubscribeFileForm::class);
     $form_object->setParagraph($paragraph);
 
-    $variables['subscribe_file_form'] = $this->formBuilder->getForm($form_object);
+    // Load form_builder lazily to avoid a service circular reference:
+    // this hook class would otherwise pull form_builder -> url_generator ->
+    // router eagerly whenever any of its hooks fire.
+    $variables['subscribe_file_form'] = \Drupal::formBuilder()->getForm($form_object);
   }
 
   /**

--- a/modules/custom/d_product/src/Hook/Hooks.php
+++ b/modules/custom/d_product/src/Hook/Hooks.php
@@ -266,8 +266,8 @@ class Hooks {
   /**
    * Build custom term links pointing to a facet path.
    *
-   * @return string[]
-   *   Rendered term link markup keyed by delta.
+   * @return array[]
+   *   Render arrays for each term link, keyed by delta.
    */
   protected function generateTermLinks(iterable $items, string $element): array {
     $links = [];
@@ -284,8 +284,8 @@ class Hooks {
         'query' => ['f[0]' => $element . ':' . strtolower($name)],
       ];
       // phpcs:ignore Drupal.Semantics.FunctionT.NotLiteralString
-      $links[] = (string) Link::fromTextAndUrl($this->t($name), Url::fromUri('internal:/products', $options))
-        ->toString();
+      $links[] = Link::fromTextAndUrl($this->t($name), Url::fromUri('internal:/products', $options))
+        ->toRenderable();
     }
     return $links;
   }

--- a/themes/custom/droopler_theme/droopler_theme.theme
+++ b/themes/custom/droopler_theme/droopler_theme.theme
@@ -325,7 +325,12 @@ function droopler_theme_preprocess_field(&$variables) {
   if ($variables['field_name'] == 'field_d_product_media') {
     $variables['#attached']['library'][] = 'd_product/d_product_slider';
     $vid = $variables['element']['#object']->vid->value;
-    $slider = views_embed_view('product_images', 'block_1', $vid);
+    $slider = [
+      '#type' => 'view',
+      '#name' => 'product_images',
+      '#display_id' => 'block_1',
+      '#arguments' => [$vid],
+    ];
     $variables['slider'] = \Drupal::service('renderer')->render($slider);
   }
 }


### PR DESCRIPTION
Bugfixes and Drupal 11.4 compatibility release.

### Fixed
- **d_p:** Apply default setting classes (padding/margin/theme) even when the paragraph settings field is empty.
- **d_p, d_block_field, d_media:** Remove `readonly` from injected services in plugins — fixes a fatal `Cannot initialize readonly property` when plugins are restored from cache (`__wakeup`).
- **d_p_subscribe_file:** Fix `form_builder` service circular reference; remove `readonly` from form services (same serialization issue).
- **d_commerce:** Fix product category links for Facets pretty paths; guard against a missing facet.
- **d_product:** Return term links as render arrays for correct cacheability.

### Drupal 11.4 compatibility
- **Profile install:** `standard_install()` was removed in Drupal 11.4 — guard the legacy call and seed the default shortcut set directly, so the profile installs on both 11.3 and 11.4.
- **d_commerce_product, droopler_theme:** Replace deprecated `views_embed_view()` with the `#type => view` render element (supported on all versions).
- **composer.json:** Allow the `symfony/runtime` Composer plugin (now pulled in by Drupal core 11.4).

### Dependencies                                                                                                                                                                                                                       
- Bump `drupal/search_api` to `^1.41` for PHP 8.5 support.